### PR TITLE
chore: bump version to 1.0.1 for ClawHub re-publish

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: narrator-ai-cli
-version: "1.0.0"
+version: "1.0.1"
 license: MIT
 description: >-
   Create AI-narrated film/drama commentary videos via CLI.

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "narrator-ai-cli-skill",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AI Agent skill for narrator-ai-cli — create AI-narrated film/drama commentary videos end-to-end via natural language commands. Supports two workflow paths, 93 movies, 146 BGM tracks, 63 dubbing voices, 90+ narration templates.",
   "author": {
     "name": "jieshuo-ai",


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 in SKILL.md and plugin.json
- Triggers ClawHub re-scan after metadata format fix (#12)

Closes #13

## Test plan
- [ ] Merge and re-publish to ClawHub
- [ ] Verify Suspicious label is removed from https://clawhub.ai/4myhime/narrator-ai-cli-skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)