### PR TITLE
fix(skill): update fast-writing billing to new per-target_mode pricing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -188,7 +188,7 @@ Detailed list commands, response shapes, and field mappings live in `references/
 3. **Not found, known title** → `task search-movie "<name>" --json` → `target_mode=1` (or `target_mode=2` if user uploads SRT). May take 60+ seconds (Gradio backend, results cached 24h).
 4. **Obscure / new content** → `target_mode=3` with user's uploaded SRT. `confirmed_movie_json` optional.
 
-**Step 1 — fast-writing**: pass `learning_model_id`, `target_mode`, `playlet_name`, `confirmed_movie_json` and/or `episodes_data`, `model` (pricing: 纯解说文案 `flash` 5pts/1k-chars or `pro` 15pts/1k-chars; 原片混剪解说文案 `flash` 12pts/1k-chars or `pro` 40pts/1k-chars). Save `task_id` from the **creation response**, then poll until top-level `.status=2` and save `.files[0].file_id` from the completed task.
+**Step 1 — fast-writing**: pass `learning_model_id`, `target_mode`, `playlet_name`, `confirmed_movie_json` and/or `episodes_data`, `model`. Pricing varies by `target_mode` — see model pricing table in `references/workflows.md` § Step 1. Save `task_id` from the **creation response**, then poll until top-level `.status=2` and save `.files[0].file_id` from the completed task. Actual cost: read `consumed_points` from `task query` — that is the authoritative charge.
 
 **Step 2 — fast-clip-data**: pass `task_id` + `file_id` from Step 1, plus `bgm`, `dubbing`, `dubbing_type`, and `episodes_data` with `video_oss_key` / `srt_oss_key` / `negative_oss_key`. Poll until top-level `.status=2`; read top-level `.task_order_num` from the response.
 

--- a/references/workflows.md
+++ b/references/workflows.md
@@ -82,7 +82,7 @@ narrator-ai-cli task create fast-writing --json -d @request.json
 | `playlet_num` | str | No | `"1"` | Episode/part number. Use `"1"` for single-episode; increment for multi-part |
 | `confirmed_movie_json` | obj | mode=1, 2; optional mode=3 | - | From material data (material found) or `search-movie` result. **Never fabricate.** |
 | `episodes_data` | list | mode=2, 3 | - | For fast-writing: `[{srt_oss_key, num}]`. For fast-clip-data: `[{video_oss_key, srt_oss_key, negative_oss_key, num}]` — video fields added at the clip-data step |
-| `model` | str | No | `"pro"` | `"pro"` (higher quality, 15 pts/char) or `"flash"` (faster, 5 pts/char) |
+| `model` | str | No | `"pro"` | `"pro"` (higher quality) or `"flash"` (faster). Pricing per thousand characters varies by `target_mode`: mode=1 → Flash 5 pts/千字, Pro 15 pts/千字; mode=2 or 3 → Flash 12 pts/千字, Pro 40 pts/千字. Actual charge: `consumed_points` in `task query` response. |
 | `language` | str | No | `"Chinese (中文)"` | Output language for the narration script. **Must match the selected dubbing voice language.** If voice is non-Chinese, set this explicitly — never leave at default |
 | `perspective` | str | No | `"third_person"` | `"first_person"` or `"third_person"` |
 | `target_character_name` | str | 1st person | - | Required when `perspective=first_person` |


### PR DESCRIPTION
Old docs stated flat 5 pts/char (flash) / 15 pts/char (pro). New pricing is per thousand characters and varies by target_mode:
- mode=1 (纯解说): Flash 5 pts/千字, Pro 15 pts/千字
- mode=2/3 (原声混剪/短剧): Flash 12 pts/千字, Pro 40 pts/千字

Also clarify that consumed_points in task query is the authoritative charge.

Closes #34