### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
   ~/.openclaw/skills/narrator-ai-cli
 ```
 
+**Autohand Code:**
+```bash
+mkdir -p ~/.autohand/skills
+git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
+  ~/.autohand/skills/narrator-ai-cli
+
+# Or install only for the current project:
+mkdir -p .autohand/skills
+git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
+  .autohand/skills/narrator-ai-cli
+```
+
 **Windsurf / Claude Code:**
 ```bash
 mkdir -p /path/to/your/project/.skills
@@ -100,6 +112,7 @@ Once installed, use natural language:
 | Platform | Setup | Status |
 |----------|-------|--------|
 | **OpenClaw** | `git clone` into skills directory | ✅ Verified |
+| **Autohand Code** | `git clone` into `~/.autohand/skills` or `.autohand/skills` | ✅ Compatible |
 | **Windsurf** | `git clone` into .skills directory | ✅ Verified |
 | **WorkBuddy** (Tencent) | Upload SKILL.md + all files in references/ | ✅ Verified |
 | **QClaw** (Tencent) | Upload SKILL.md + all files in references/ | ✅ Verified |

--- a/README_CN.md
+++ b/README_CN.md
@@ -55,6 +55,18 @@ git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
   ~/.openclaw/skills/narrator-ai-cli
 ```
 
+**Autohand Code：**
+```bash
+mkdir -p ~/.autohand/skills
+git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
+  ~/.autohand/skills/narrator-ai-cli
+
+# 或者只安装到当前项目：
+mkdir -p .autohand/skills
+git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
+  .autohand/skills/narrator-ai-cli
+```
+
 **Windsurf / Claude Code：**
 ```bash
 mkdir -p /path/to/your/project/.skills
@@ -100,6 +112,7 @@ git clone https://github.com/NarratorAI-Studio/narrator-ai-cli-skill.git \
 | 平台 | 安装方式 | 状态 |
 |------|---------|------|
 | **小龙虾 OpenClaw** | `git clone` 到技能目录 | ✅ 已验证 |
+| **Autohand Code** | `git clone` 到 `~/.autohand/skills` 或 `.autohand/skills` | ✅ 兼容 |
 | **WorkBuddy**（腾讯） | 上传 SKILL.md + references/ 全部文件 | ✅ 已验证 |
 | **QClaw**（腾讯） | 上传 SKILL.md + references/ 全部文件 | ✅ 已验证 |
 | **Windsurf** | `git clone` 到 .skills 目录 | ✅ 已验证 |


### PR DESCRIPTION
## Summary

Adds Autohand Code install instructions to the English and Chinese READMEs.

The new snippets clone the whole skill package, preserving `SKILL.md` and `references/`, into:

- `~/.autohand/skills/narrator-ai-cli`
- `.autohand/skills/narrator-ai-cli`

I did not claim catalog or marketplace support because this repository does not appear in the current public Autohand Skills index.

## Validation

- `git diff --check`

No repo-level contribution guide or test command was present, so this is limited to README installation documentation.