### PR TITLE
docs: add optional MiniMax video generation workflow

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -45,6 +45,7 @@ This file covers decision flow, the common workflow, and pointers. Detailed look
 | Resource selection (material / BGM / dubbing / templates) — list commands, response formats, field mapping | `references/resources.md` |
 | Full workflow steps with parameter tables and JSON examples (Fast Path + Standard Path) | `references/workflows.md` |
 | Magic Video — optional visual template step (catalog, params, language rules) | `references/magic-video.md` |
+| MiniMax video generation — optional text/image-to-video assets before file import | `references/minimax-video-generation.md` |
 | Polling pattern, task types, file ops, user account, error codes | `references/operations.md` |
 
 ## Pipeline at a Glance
@@ -68,7 +69,7 @@ This file covers decision flow, the common workflow, and pointers. Detailed look
 ## Agent Rules (mandatory — apply across all steps)
 
 > **Always:**
-> - **Confirm before acting.** Every resource (source, BGM, dubbing, template) and every `magic-video` submission requires explicit user approval. Never auto-select, never auto-submit.
+> - **Confirm before acting.** Every resource (source, BGM, dubbing, template), every `magic-video` submission, and every optional MiniMax video generation request requires explicit user approval. Never auto-select, never auto-submit.
 > - **Source data, never invent.** Construct `confirmed_movie_json` from `material list` fields or `task search-movie` output. If neither yields it, ask the user — do not fabricate.
 > - **Honor the language chain.** The dubbing voice's language defines the writing task `language` param AND every `magic-video` text param. All three must match. → `references/magic-video.md` § Language Awareness
 > - **Paginate `material list` to exhaustion, search programmatically.** Fetch all pages until `total` is consumed, then `grep -i` or `python3 -c` on the JSON. Never trust truncated terminal display.
@@ -238,7 +239,8 @@ Both accept optional `clone_model` (default: `pro`).
 
 ## Data & Privacy
 
-- **API endpoint**: All requests go to `https://openapi.jieshuo.cn`. No third-party services.
+- **Default API endpoint**: Narrator AI workflow requests go to `https://openapi.jieshuo.cn`.
+- **Optional MiniMax endpoint**: MiniMax video generation sends the approved prompt and optional first-frame image to the selected global or China API endpoint. See `references/minimax-video-generation.md`.
 - **File upload**: presigned URL → OSS PUT → callback. Files are bound to your account, not public.
-- **Credentials**: `NARRATOR_APP_KEY` stored at `~/.narrator-ai/config.yaml`. Keep private; do not commit.
+- **Credentials**: `NARRATOR_APP_KEY` is stored at `~/.narrator-ai/config.yaml`; `MINIMAX_API_KEY` stays in the environment. Keep both private and never commit them.
 - **Scope**: this skill only orchestrates the CLI; it does not access files outside what you explicitly pass as input.

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,7 +45,7 @@ This file covers decision flow, the common workflow, and pointers. Detailed look
 | Resource selection (material / BGM / dubbing / templates) — list commands, response formats, field mapping | `references/resources.md` |
 | Full workflow steps with parameter tables and JSON examples (Fast Path + Standard Path) | `references/workflows.md` |
 | Magic Video — optional visual template step (catalog, params, language rules) | `references/magic-video.md` |
-| MiniMax video generation — optional text/image-to-video assets before file import | `references/minimax-video-generation.md` |
+| MiniMax video generation — optional text, image, and reference-to-video assets before file import | `references/minimax-video-generation.md` |
 | Polling pattern, task types, file ops, user account, error codes | `references/operations.md` |
 
 ## Pipeline at a Glance
@@ -240,7 +240,7 @@ Both accept optional `clone_model` (default: `pro`).
 ## Data & Privacy
 
 - **Default API endpoint**: Narrator AI workflow requests go to `https://openapi.jieshuo.cn`.
-- **Optional MiniMax endpoint**: MiniMax video generation sends the approved prompt and optional first-frame image to the selected global or China API endpoint. See `references/minimax-video-generation.md`.
+- **Optional MiniMax endpoint**: MiniMax video generation sends the approved prompt and any approved image, video, or audio references to the selected global or China API endpoint. See `references/minimax-video-generation.md`.
 - **File upload**: presigned URL → OSS PUT → callback. Files are bound to your account, not public.
 - **Credentials**: `NARRATOR_APP_KEY` is stored at `~/.narrator-ai/config.yaml`; `MINIMAX_API_KEY` stays in the environment. Keep both private and never commit them.
 - **Scope**: this skill orchestrates the CLI and optional approved video-generation requests; it does not access files outside what you explicitly pass as input.

--- a/SKILL.md
+++ b/SKILL.md
@@ -243,4 +243,4 @@ Both accept optional `clone_model` (default: `pro`).
 - **Optional MiniMax endpoint**: MiniMax video generation sends the approved prompt and optional first-frame image to the selected global or China API endpoint. See `references/minimax-video-generation.md`.
 - **File upload**: presigned URL → OSS PUT → callback. Files are bound to your account, not public.
 - **Credentials**: `NARRATOR_APP_KEY` is stored at `~/.narrator-ai/config.yaml`; `MINIMAX_API_KEY` stays in the environment. Keep both private and never commit them.
-- **Scope**: this skill only orchestrates the CLI; it does not access files outside what you explicitly pass as input.
+- **Scope**: this skill orchestrates the CLI and optional approved video-generation requests; it does not access files outside what you explicitly pass as input.

--- a/references/minimax-video-generation.md
+++ b/references/minimax-video-generation.md
@@ -4,53 +4,92 @@
 
 Use this optional path only when the user explicitly asks for a generated video asset, such as original B-roll, a transition, or a standalone clip for a Narrator AI project. It is not part of the default narration pipeline and must not replace source footage unless the user has the right to generate and use that footage.
 
+This reference covers both MiniMax video API generations:
+
+- **v2 default:** `MiniMax-H3` with content-based requests at `/v2/video_generation`.
+- **v1 compatibility:** the listed Hailuo, T2V, and I2V models with prompt-based requests at `/v1/video_generation`.
+
 ## Confirm Before Submitting
 
 A generation request may be billable and irreversible. Before the `POST` request, show the user and confirm:
 
-- the selected API region and video model
-- text-to-video or image-to-video mode
-- the exact prompt and, for image-to-video, the first-frame image
-- every optional request field, including duration and resolution
+- the selected API region, API version, and video model
+- text-to-video, image-to-video, first/last-frame-to-video, or reference-to-video mode
+- the exact prompt and every image, video, or audio content item
+- every optional request field, including ratio, callback URL, and the China-only `aigc_watermark` field
+- the required resolution and duration
 - the maximum number of five-second status checks
-- the expected cost shown by the current MiniMax pricing documentation
+- the expected cost calculated from the selected region's pricing below
 
 Do not automatically retry the generation `POST`. A retry can create and charge for a duplicate task.
 
-## Configure the Region and Credentials
+For a v2 `MiniMax-H3` request, also enforce these limits before asking for final approval:
 
-Choose one region with the user. Keep the API key in the environment and never place it in `request.json` or a committed file.
+- include one non-empty text item; total text must not exceed 7,000 characters
+- use `2K` resolution and an integer duration from 4 through 15 seconds
+- use only `text`, `image_url`, `video_url`, and `audio_url` content types
+- use only `first_frame`, `last_frame`, `reference_image`, `reference_video`, and `reference_audio` roles
+- include an image or video when using `reference_audio`
+- do not mix first/last-frame roles with reference roles in the same request
+- keep the complete request body at or below 64 MB
+
+## Regions, Models, and Pricing
+
+Choose one regional API origin with the user:
+
+| Region | API origin | v2 create endpoint | v1 create endpoint |
+|---|---|---|---|
+| Global | `https://api.minimax.io` | `https://api.minimax.io/v2/video_generation` | `https://api.minimax.io/v1/video_generation` |
+| China | `https://api.minimaxi.com` | `https://api.minimaxi.com/v2/video_generation` | `https://api.minimaxi.com/v1/video_generation` |
+
+| API version | Models |
+|---|---|
+| v2 | `MiniMax-H3` (default) |
+| v1 | `MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, `T2V-01-Director`, `T2V-01`, `I2V-01-Director`, `I2V-01-live`, `I2V-01` |
+
+`MiniMax-H3` was released on 2026-07-31. It accepts text, image, video, and audio input; supports text-to-video, image-to-video, first/last-frame-to-video, and reference-to-video; and returns video and audio output.
+
+| Region | Output video | Reference video | Reference audio | Reference images |
+|---|---|---|---|---|
+| Global | USD 0.13 per 2K output second | USD 0.02 per 2K input second | Free | First 5 free, then USD 0.03 per image |
+| China | CNY 0.8 per 2K output second | CNY 0.8 per 2K input second | Free | First 5 free, then CNY 0.2 per image |
+
+Keep the API key in the environment and never place it in `request.json` or a committed file.
 
 ```bash
 export MINIMAX_API_KEY="<your MiniMax API key>"
 
 # Global
-export MINIMAX_API_BASE="https://api.minimax.io/v1"
+export MINIMAX_API_BASE="https://api.minimax.io"
 
 # China (use this instead of the global value when selected)
-# export MINIMAX_API_BASE="https://api.minimaxi.com/v1"
-```
+# export MINIMAX_API_BASE="https://api.minimaxi.com"
 
-Select a currently supported model from the official API reference immediately before building the request. Model availability and valid option combinations can change, so do not guess or reuse a stale model ID.
-
-| Region | Text-to-video reference | Image-to-video reference |
-|---|---|---|
-| Global | https://platform.minimax.io/docs/api-reference/video-generation-t2v | https://platform.minimax.io/docs/api-reference/video-generation-i2v |
-| China | https://platform.minimaxi.com/docs/api-reference/video-generation-t2v | https://platform.minimaxi.com/docs/api-reference/video-generation-i2v |
-
-```bash
-export MINIMAX_VIDEO_MODEL="<model ID from the selected region's current API reference>"
+export MINIMAX_VIDEO_API_VERSION="${MINIMAX_VIDEO_API_VERSION:-v2}"
+export MINIMAX_VIDEO_MODEL="${MINIMAX_VIDEO_MODEL:-MiniMax-H3}"
 export MINIMAX_MAX_POLLS="<approved positive integer>"
 
 case "${MINIMAX_API_KEY:-}" in
   ""|"<"*) echo "Set MINIMAX_API_KEY before continuing." >&2; exit 1 ;;
 esac
-case "${MINIMAX_VIDEO_MODEL:-}" in
-  ""|"<"*) echo "Set MINIMAX_VIDEO_MODEL before continuing." >&2; exit 1 ;;
-esac
 case "${MINIMAX_API_BASE:-}" in
-  https://api.minimax.io/v1|https://api.minimaxi.com/v1) ;;
+  https://api.minimax.io|https://api.minimaxi.com) ;;
   *) echo "Select a documented MINIMAX_API_BASE value." >&2; exit 1 ;;
+esac
+case "${MINIMAX_VIDEO_API_VERSION:-}" in
+  v2)
+    [ "$MINIMAX_VIDEO_MODEL" = "MiniMax-H3" ] || {
+      echo "MiniMax-H3 is the supported v2 model." >&2
+      exit 1
+    }
+    ;;
+  v1)
+    case "$MINIMAX_VIDEO_MODEL" in
+      MiniMax-Hailuo-2.3|MiniMax-Hailuo-2.3-Fast|MiniMax-Hailuo-02|T2V-01-Director|T2V-01|I2V-01-Director|I2V-01-live|I2V-01) ;;
+      *) echo "Select a documented v1 video model." >&2; exit 1 ;;
+    esac
+    ;;
+  *) echo "Set MINIMAX_VIDEO_API_VERSION to v2 or v1." >&2; exit 1 ;;
 esac
 case "${MINIMAX_MAX_POLLS:-}" in
   ""|"<"*|0*|*[!0-9]*)
@@ -60,37 +99,70 @@ case "${MINIMAX_MAX_POLLS:-}" in
 esac
 ```
 
-## Build the Approved Request
+## Build a v2 Request
 
-For text-to-video, start with only the required fields. Add optional fields only when they appear in the current API reference and the user has approved their values.
+The v2 create operation requires `model`, `content`, `resolution`, and `duration`. `ratio` and `callback_url` are optional. The allowed ratio values are `adaptive`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, and `9:16`.
 
-```bash
-jq -n \
-  --arg model "$MINIMAX_VIDEO_MODEL" \
-  --arg prompt "<approved prompt>" \
-  '{model: $model, prompt: $prompt}' > request.json
-```
-
-For image-to-video, add the approved first-frame image. The API accepts a public image URL or a Base64 data URL; check the current size, format, dimension, and aspect-ratio requirements before submitting.
+For text-to-video, start with the required text content:
 
 ```bash
+PROMPT="<approved prompt>"
+DURATION_SECONDS=5
+
 jq -n \
   --arg model "$MINIMAX_VIDEO_MODEL" \
-  --arg prompt "<approved prompt>" \
-  --arg first_frame_image "<approved image URL or data URL>" \
-  '{model: $model, prompt: $prompt, first_frame_image: $first_frame_image}' > request.json
+  --arg prompt "$PROMPT" \
+  --argjson duration "$DURATION_SECONDS" \
+  '{
+    model: $model,
+    content: [
+      {type: "text", text: $prompt}
+    ],
+    resolution: "2K",
+    duration: $duration
+  }' > request.json
 ```
+
+For image-to-video, add the approved image as a `first_frame` content item:
+
+```bash
+PROMPT="<approved prompt>"
+FIRST_FRAME_URL="<approved image URL>"
+DURATION_SECONDS=5
+
+jq -n \
+  --arg model "$MINIMAX_VIDEO_MODEL" \
+  --arg prompt "$PROMPT" \
+  --arg first_frame_url "$FIRST_FRAME_URL" \
+  --argjson duration "$DURATION_SECONDS" \
+  '{
+    model: $model,
+    content: [
+      {type: "text", text: $prompt},
+      {
+        type: "image_url",
+        image_url: {url: $first_frame_url},
+        role: "first_frame"
+      }
+    ],
+    resolution: "2K",
+    duration: $duration,
+    ratio: "adaptive"
+  }' > request.json
+```
+
+Use `last_frame`, `reference_image`, `reference_video`, or `reference_audio` only when that role matches the user's approved mode. Add `callback_url` only when the user approved it. Add `aigc_watermark` only for the China endpoint and only after approval.
 
 Show the complete `request.json` to the user and get final confirmation before continuing.
 
-## Create the Task
+## Create the v2 Task
 
 ```bash
 jq -e 'type == "object"' request.json >/dev/null || exit 1
 
 if ! CREATE_RESPONSE="$(curl -sS --fail-with-body \
   --connect-timeout 10 --max-time 60 \
-  -X POST "$MINIMAX_API_BASE/video_generation" \
+  -X POST "$MINIMAX_API_BASE/v2/video_generation" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -H "Content-Type: application/json" \
   -d @request.json)"; then
@@ -98,84 +170,84 @@ if ! CREATE_RESPONSE="$(curl -sS --fail-with-body \
   exit 1
 fi
 
-printf '%s\n' "$CREATE_RESPONSE" | jq . || exit 1
-[ "$(jq -r '.base_resp.status_code' <<<"$CREATE_RESPONSE")" = "0" ] || exit 1
+jq -e . >/dev/null <<<"$CREATE_RESPONSE" || exit 1
 TASK_ID="$(jq -r '.task_id // empty' <<<"$CREATE_RESPONSE")"
-[ -n "$TASK_ID" ] || exit 1
+[ -n "$TASK_ID" ] || {
+  printf '%s\n' "$CREATE_RESPONSE" | jq .
+  exit 1
+}
 ```
 
 Do not repeat this command automatically if the response is interrupted or ambiguous. Query the returned task ID when available; otherwise ask the user before creating another task.
 
-## Poll and Retrieve the Video
+## Poll and Retrieve the v2 Result
 
-Poll at five-second intervals until the API returns a terminal status. Stop on unknown statuses instead of guessing.
+Poll `GET /v2/query/video_generation/{task_id}` at five-second intervals. The response exposes `task.id`, `task.model`, `task.status`, `task.error`, `task.content.url`, `task.resolution`, `task.duration`, `task.usage.total_seconds`, `task.usage.input_seconds`, `task.usage.output_seconds`, `task.usage.image_count`, `task.ratio`, `task.task_type`, and `task.modality`.
 
 ```bash
 POLL_COUNT=0
-STATUS=""
+TASK_STATUS=""
+DOWNLOAD_URL=""
+
 while [ "$POLL_COUNT" -lt "$MINIMAX_MAX_POLLS" ]; do
   POLL_COUNT=$((POLL_COUNT + 1))
   if ! STATUS_RESPONSE="$(curl -sS --fail-with-body \
     --connect-timeout 10 --max-time 60 \
-    -G "$MINIMAX_API_BASE/query/video_generation" \
-    -H "Authorization: Bearer $MINIMAX_API_KEY" \
-    --data-urlencode "task_id=$TASK_ID")"; then
+    "$MINIMAX_API_BASE/v2/query/video_generation/$TASK_ID" \
+    -H "Authorization: Bearer $MINIMAX_API_KEY")"; then
     echo "Status request failed or timed out." >&2
     exit 1
   fi
 
   jq -e . >/dev/null <<<"$STATUS_RESPONSE" || exit 1
-  [ "$(jq -r '.base_resp.status_code' <<<"$STATUS_RESPONSE")" = "0" ] || {
-    printf '%s\n' "$STATUS_RESPONSE" | jq .
-    exit 1
-  }
+  TASK_STATUS="$(jq -r '.task.status // empty' <<<"$STATUS_RESPONSE")"
+  echo "task=$TASK_ID status=$TASK_STATUS"
 
-  STATUS="$(jq -r '.status // empty' <<<"$STATUS_RESPONSE")"
-  echo "task=$TASK_ID status=$STATUS"
-  case "$STATUS" in
-    Success)
-      FILE_ID="$(jq -r '.file_id // empty' <<<"$STATUS_RESPONSE")"
-      [ -n "$FILE_ID" ] || exit 1
-      break
-      ;;
-    Fail)
-      printf '%s\n' "$STATUS_RESPONSE" | jq .
-      exit 1
-      ;;
-    Preparing|Queueing|Processing)
+  case "$TASK_STATUS" in
+    queued|running)
       [ "$POLL_COUNT" -ge "$MINIMAX_MAX_POLLS" ] || sleep 5
       ;;
+    succeeded)
+      DOWNLOAD_URL="$(jq -r '.task.content.url // empty' <<<"$STATUS_RESPONSE")"
+      [ -n "$DOWNLOAD_URL" ] || exit 1
+      break
+      ;;
+    failed|cancelled)
+      printf '%s\n' "$STATUS_RESPONSE" | jq '{status: .task.status, error: .task.error}'
+      exit 1
+      ;;
     *)
-      echo "Unknown video generation status: $STATUS"
+      echo "Unknown video generation status: $TASK_STATUS" >&2
       exit 1
       ;;
   esac
 done
 
-[ "$STATUS" = "Success" ] || {
+[ "$TASK_STATUS" = "succeeded" ] || {
   echo "Polling stopped after $MINIMAX_MAX_POLLS status checks." >&2
   exit 1
 }
-
-if ! FILE_RESPONSE="$(curl -sS --fail-with-body \
-  --connect-timeout 10 --max-time 60 \
-  -G "$MINIMAX_API_BASE/files/retrieve" \
-  -H "Authorization: Bearer $MINIMAX_API_KEY" \
-  --data-urlencode "file_id=$FILE_ID")"; then
-  echo "File retrieval failed or timed out." >&2
-  exit 1
-fi
-
-jq -e . >/dev/null <<<"$FILE_RESPONSE" || exit 1
-[ "$(jq -r '.base_resp.status_code' <<<"$FILE_RESPONSE")" = "0" ] || {
-  printf '%s\n' "$FILE_RESPONSE" | jq .
-  exit 1
-}
-DOWNLOAD_URL="$(jq -r '.file.download_url // empty' <<<"$FILE_RESPONSE")"
-[ -n "$DOWNLOAD_URL" ] || exit 1
 ```
 
-The download URL is temporary. Import it promptly if the user wants to use the asset in the narration workflow:
+The v2 API also supports task management. Listing accepts `page_num`, `page_size`, `filter.status`, `filter.task_ids`, `filter.model`, and `filter.task_type`; the response contains `items` and `total`.
+
+```bash
+# List tasks. Add approved filter fields when needed.
+curl -sS --fail-with-body \
+  --connect-timeout 10 --max-time 60 \
+  -G "$MINIMAX_API_BASE/v2/query/video_generation" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  --data-urlencode "page_num=1" \
+  --data-urlencode "page_size=20" | jq '{items, total}'
+
+# Delete or cancel one approved task.
+curl -sS --fail-with-body \
+  --connect-timeout 10 --max-time 60 \
+  -X DELETE "$MINIMAX_API_BASE/v2/video_generation/$TASK_ID" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" | jq '{task_id, action, status}'
+```
+
+Import the completed video only after the user approves the result:
 
 ```bash
 narrator-ai-cli file transfer --link "$DOWNLOAD_URL" --json
@@ -183,9 +255,121 @@ narrator-ai-cli file transfer --link "$DOWNLOAD_URL" --json
 
 Show the imported file details and get user confirmation before using its `file_id` in any downstream task. Keep normal source, subtitle, BGM, dubbing, and narration-template selection in the standard Narrator AI workflow.
 
-## Official Status and Download References
+## v1 Compatibility Workflow
 
-| Region | Task status | File download |
-|---|---|---|
-| Global | https://platform.minimax.io/docs/api-reference/video-generation-query | https://platform.minimax.io/docs/api-reference/video-generation-download |
-| China | https://platform.minimaxi.com/docs/api-reference/video-generation-query | https://platform.minimaxi.com/docs/api-reference/video-generation-download |
+Use v1 only when the selected approved model is one of the documented v1 models. Text-to-video requires `model` and `prompt`. Image-to-video requires `model` and `first_frame_image`; `prompt` is optional. Supported optional fields are `prompt_optimizer`, `fast_pretreatment`, `duration`, `resolution`, and `callback_url`.
+
+```bash
+# Text-to-video
+jq -n \
+  --arg model "$MINIMAX_VIDEO_MODEL" \
+  --arg prompt "<approved prompt>" \
+  '{model: $model, prompt: $prompt}' > request.json
+
+# Image-to-video
+jq -n \
+  --arg model "$MINIMAX_VIDEO_MODEL" \
+  --arg prompt "<approved prompt>" \
+  --arg first_frame_image "<approved image URL or data URL>" \
+  '{
+    model: $model,
+    prompt: $prompt,
+    first_frame_image: $first_frame_image
+  }' > request.json
+```
+
+Create and query the v1 task with Bearer authorization:
+
+```bash
+if ! CREATE_RESPONSE="$(curl -sS --fail-with-body \
+  --connect-timeout 10 --max-time 60 \
+  -X POST "$MINIMAX_API_BASE/v1/video_generation" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @request.json)"; then
+  echo "Task creation failed or timed out; do not resubmit automatically." >&2
+  exit 1
+fi
+
+jq -e . >/dev/null <<<"$CREATE_RESPONSE" || exit 1
+[ "$(jq -r '.base_resp.status_code // empty' <<<"$CREATE_RESPONSE")" = "0" ] || {
+  printf '%s\n' "$CREATE_RESPONSE" | jq .
+  exit 1
+}
+TASK_ID="$(jq -r '.task_id // empty' <<<"$CREATE_RESPONSE")"
+[ -n "$TASK_ID" ] || exit 1
+
+POLL_COUNT=0
+TASK_STATUS=""
+FILE_ID=""
+DOWNLOAD_URL=""
+
+while [ "$POLL_COUNT" -lt "$MINIMAX_MAX_POLLS" ]; do
+  POLL_COUNT=$((POLL_COUNT + 1))
+  STATUS_RESPONSE="$(curl -sS --fail-with-body \
+    --connect-timeout 10 --max-time 60 \
+    -G "$MINIMAX_API_BASE/v1/query/video_generation" \
+    -H "Authorization: Bearer $MINIMAX_API_KEY" \
+    --data-urlencode "task_id=$TASK_ID")" || exit 1
+
+  jq -e . >/dev/null <<<"$STATUS_RESPONSE" || exit 1
+  TASK_STATUS="$(jq -r '.status // .task.status // empty' <<<"$STATUS_RESPONSE")"
+  echo "task=$TASK_ID status=$TASK_STATUS"
+
+  case "$TASK_STATUS" in
+    Preparing|Queueing|Processing)
+      [ "$POLL_COUNT" -ge "$MINIMAX_MAX_POLLS" ] || sleep 5
+      ;;
+    Success)
+      DOWNLOAD_URL="$(jq -r '.task.content.url // empty' <<<"$STATUS_RESPONSE")"
+      FILE_ID="$(jq -r '.file_id // empty' <<<"$STATUS_RESPONSE")"
+      [ -n "$DOWNLOAD_URL" ] || [ -n "$FILE_ID" ] || exit 1
+      break
+      ;;
+    Fail)
+      printf '%s\n' "$STATUS_RESPONSE" | jq .
+      exit 1
+      ;;
+    *)
+      echo "Unknown video generation status: $TASK_STATUS" >&2
+      exit 1
+      ;;
+  esac
+done
+
+[ "$TASK_STATUS" = "Success" ] || {
+  echo "Polling stopped after $MINIMAX_MAX_POLLS status checks." >&2
+  exit 1
+}
+
+if [ -z "$DOWNLOAD_URL" ]; then
+  FILE_RESPONSE="$(curl -sS --fail-with-body \
+    --connect-timeout 10 --max-time 60 \
+    -G "$MINIMAX_API_BASE/v1/files/retrieve" \
+    -H "Authorization: Bearer $MINIMAX_API_KEY" \
+    --data-urlencode "file_id=$FILE_ID")" || exit 1
+
+  jq -e . >/dev/null <<<"$FILE_RESPONSE" || exit 1
+  [ "$(jq -r '.base_resp.status_code // empty' <<<"$FILE_RESPONSE")" = "0" ] || exit 1
+  DOWNLOAD_URL="$(jq -r '.file.download_url // empty' <<<"$FILE_RESPONSE")"
+  [ -n "$DOWNLOAD_URL" ] || exit 1
+fi
+```
+
+Import the approved v1 result with the same `narrator-ai-cli file transfer --link "$DOWNLOAD_URL" --json` command used for v2.
+
+## Official References
+
+### v2
+
+| Region | Create | Query | List | Delete | OpenAPI |
+|---|---|---|---|---|---|
+| Global | https://platform.minimax.io/docs/api-reference/video-generation-v2-create | https://platform.minimax.io/docs/api-reference/video-generation-v2-query | https://platform.minimax.io/docs/api-reference/video-generation-v2-list | https://platform.minimax.io/docs/api-reference/video-generation-v2-delete | https://platform.minimax.io/docs/api-reference/video/generation/api/v2-video-generation.json |
+| China | https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create | https://platform.minimaxi.com/docs/api-reference/video-generation-v2-query | https://platform.minimaxi.com/docs/api-reference/video-generation-v2-list | https://platform.minimaxi.com/docs/api-reference/video-generation-v2-delete | https://platform.minimaxi.com/docs/api-reference/video/generation/api/v2-video-generation.json |
+
+### v1
+
+| Region | Text-to-video | Image-to-video | Query | Download | Text OpenAPI | Image OpenAPI |
+|---|---|---|---|---|---|---|
+| Global | https://platform.minimax.io/docs/api-reference/video-generation-t2v | https://platform.minimax.io/docs/api-reference/video-generation-i2v | https://platform.minimax.io/docs/api-reference/video-generation-query | https://platform.minimax.io/docs/api-reference/video-generation-download | https://platform.minimax.io/docs/api-reference/video/generation/api/text-to-video.json | https://platform.minimax.io/docs/api-reference/video/generation/api/image-to-video.json |
+| China | https://platform.minimaxi.com/docs/api-reference/video-generation-t2v | https://platform.minimaxi.com/docs/api-reference/video-generation-i2v | https://platform.minimaxi.com/docs/api-reference/video-generation-query | https://platform.minimaxi.com/docs/api-reference/video-generation-download | https://platform.minimaxi.com/docs/api-reference/video/generation/api/text-to-video.json | https://platform.minimaxi.com/docs/api-reference/video/generation/api/image-to-video.json |

--- a/references/minimax-video-generation.md
+++ b/references/minimax-video-generation.md
@@ -12,6 +12,7 @@ A generation request may be billable and irreversible. Before the `POST` request
 - text-to-video or image-to-video mode
 - the exact prompt and, for image-to-video, the first-frame image
 - every optional request field, including duration and resolution
+- the maximum number of five-second status checks
 - the expected cost shown by the current MiniMax pricing documentation
 
 Do not automatically retry the generation `POST`. A retry can create and charge for a duplicate task.
@@ -39,6 +40,24 @@ Select a currently supported model from the official API reference immediately b
 
 ```bash
 export MINIMAX_VIDEO_MODEL="<model ID from the selected region's current API reference>"
+export MINIMAX_MAX_POLLS="<approved positive integer>"
+
+case "${MINIMAX_API_KEY:-}" in
+  ""|"<"*) echo "Set MINIMAX_API_KEY before continuing." >&2; exit 1 ;;
+esac
+case "${MINIMAX_VIDEO_MODEL:-}" in
+  ""|"<"*) echo "Set MINIMAX_VIDEO_MODEL before continuing." >&2; exit 1 ;;
+esac
+case "${MINIMAX_API_BASE:-}" in
+  https://api.minimax.io/v1|https://api.minimaxi.com/v1) ;;
+  *) echo "Select a documented MINIMAX_API_BASE value." >&2; exit 1 ;;
+esac
+case "${MINIMAX_MAX_POLLS:-}" in
+  ""|"<"*|0*|*[!0-9]*)
+    echo "Set MINIMAX_MAX_POLLS to a positive integer." >&2
+    exit 1
+    ;;
+esac
 ```
 
 ## Build the Approved Request
@@ -67,14 +86,21 @@ Show the complete `request.json` to the user and get final confirmation before c
 ## Create the Task
 
 ```bash
-CREATE_RESPONSE="$(curl -sS -X POST "$MINIMAX_API_BASE/video_generation" \
+jq -e 'type == "object"' request.json >/dev/null || exit 1
+
+if ! CREATE_RESPONSE="$(curl -sS --fail-with-body \
+  --connect-timeout 10 --max-time 60 \
+  -X POST "$MINIMAX_API_BASE/video_generation" \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d @request.json)"
+  -d @request.json)"; then
+  echo "Task creation failed or timed out; do not resubmit automatically." >&2
+  exit 1
+fi
 
-echo "$CREATE_RESPONSE" | jq .
-[ "$(echo "$CREATE_RESPONSE" | jq -r '.base_resp.status_code')" = "0" ] || exit 1
-TASK_ID="$(echo "$CREATE_RESPONSE" | jq -r '.task_id // empty')"
+printf '%s\n' "$CREATE_RESPONSE" | jq . || exit 1
+[ "$(jq -r '.base_resp.status_code' <<<"$CREATE_RESPONSE")" = "0" ] || exit 1
+TASK_ID="$(jq -r '.task_id // empty' <<<"$CREATE_RESPONSE")"
 [ -n "$TASK_ID" ] || exit 1
 ```
 
@@ -85,30 +111,39 @@ Do not repeat this command automatically if the response is interrupted or ambig
 Poll at five-second intervals until the API returns a terminal status. Stop on unknown statuses instead of guessing.
 
 ```bash
-while true; do
-  STATUS_RESPONSE="$(curl -sS -G "$MINIMAX_API_BASE/query/video_generation" \
+POLL_COUNT=0
+STATUS=""
+while [ "$POLL_COUNT" -lt "$MINIMAX_MAX_POLLS" ]; do
+  POLL_COUNT=$((POLL_COUNT + 1))
+  if ! STATUS_RESPONSE="$(curl -sS --fail-with-body \
+    --connect-timeout 10 --max-time 60 \
+    -G "$MINIMAX_API_BASE/query/video_generation" \
     -H "Authorization: Bearer $MINIMAX_API_KEY" \
-    --data-urlencode "task_id=$TASK_ID")"
+    --data-urlencode "task_id=$TASK_ID")"; then
+    echo "Status request failed or timed out." >&2
+    exit 1
+  fi
 
-  [ "$(echo "$STATUS_RESPONSE" | jq -r '.base_resp.status_code')" = "0" ] || {
-    echo "$STATUS_RESPONSE" | jq .
+  jq -e . >/dev/null <<<"$STATUS_RESPONSE" || exit 1
+  [ "$(jq -r '.base_resp.status_code' <<<"$STATUS_RESPONSE")" = "0" ] || {
+    printf '%s\n' "$STATUS_RESPONSE" | jq .
     exit 1
   }
 
-  STATUS="$(echo "$STATUS_RESPONSE" | jq -r '.status // empty')"
+  STATUS="$(jq -r '.status // empty' <<<"$STATUS_RESPONSE")"
   echo "task=$TASK_ID status=$STATUS"
   case "$STATUS" in
     Success)
-      FILE_ID="$(echo "$STATUS_RESPONSE" | jq -r '.file_id // empty')"
+      FILE_ID="$(jq -r '.file_id // empty' <<<"$STATUS_RESPONSE")"
       [ -n "$FILE_ID" ] || exit 1
       break
       ;;
     Fail)
-      echo "$STATUS_RESPONSE" | jq .
+      printf '%s\n' "$STATUS_RESPONSE" | jq .
       exit 1
       ;;
     Preparing|Queueing|Processing)
-      sleep 5
+      [ "$POLL_COUNT" -ge "$MINIMAX_MAX_POLLS" ] || sleep 5
       ;;
     *)
       echo "Unknown video generation status: $STATUS"
@@ -117,15 +152,26 @@ while true; do
   esac
 done
 
-FILE_RESPONSE="$(curl -sS -G "$MINIMAX_API_BASE/files/retrieve" \
-  -H "Authorization: Bearer $MINIMAX_API_KEY" \
-  --data-urlencode "file_id=$FILE_ID")"
-
-[ "$(echo "$FILE_RESPONSE" | jq -r '.base_resp.status_code')" = "0" ] || {
-  echo "$FILE_RESPONSE" | jq .
+[ "$STATUS" = "Success" ] || {
+  echo "Polling stopped after $MINIMAX_MAX_POLLS status checks." >&2
   exit 1
 }
-DOWNLOAD_URL="$(echo "$FILE_RESPONSE" | jq -r '.file.download_url // empty')"
+
+if ! FILE_RESPONSE="$(curl -sS --fail-with-body \
+  --connect-timeout 10 --max-time 60 \
+  -G "$MINIMAX_API_BASE/files/retrieve" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  --data-urlencode "file_id=$FILE_ID")"; then
+  echo "File retrieval failed or timed out." >&2
+  exit 1
+fi
+
+jq -e . >/dev/null <<<"$FILE_RESPONSE" || exit 1
+[ "$(jq -r '.base_resp.status_code' <<<"$FILE_RESPONSE")" = "0" ] || {
+  printf '%s\n' "$FILE_RESPONSE" | jq .
+  exit 1
+}
+DOWNLOAD_URL="$(jq -r '.file.download_url // empty' <<<"$FILE_RESPONSE")"
 [ -n "$DOWNLOAD_URL" ] || exit 1
 ```
 

--- a/references/minimax-video-generation.md
+++ b/references/minimax-video-generation.md
@@ -1,0 +1,145 @@
+# MiniMax Video Generation (Optional)
+
+> Back to [SKILL.md](../SKILL.md)
+
+Use this optional path only when the user explicitly asks for a generated video asset, such as original B-roll, a transition, or a standalone clip for a Narrator AI project. It is not part of the default narration pipeline and must not replace source footage unless the user has the right to generate and use that footage.
+
+## Confirm Before Submitting
+
+A generation request may be billable and irreversible. Before the `POST` request, show the user and confirm:
+
+- the selected API region and video model
+- text-to-video or image-to-video mode
+- the exact prompt and, for image-to-video, the first-frame image
+- every optional request field, including duration and resolution
+- the expected cost shown by the current MiniMax pricing documentation
+
+Do not automatically retry the generation `POST`. A retry can create and charge for a duplicate task.
+
+## Configure the Region and Credentials
+
+Choose one region with the user. Keep the API key in the environment and never place it in `request.json` or a committed file.
+
+```bash
+export MINIMAX_API_KEY="<your MiniMax API key>"
+
+# Global
+export MINIMAX_API_BASE="https://api.minimax.io/v1"
+
+# China (use this instead of the global value when selected)
+# export MINIMAX_API_BASE="https://api.minimaxi.com/v1"
+```
+
+Select a currently supported model from the official API reference immediately before building the request. Model availability and valid option combinations can change, so do not guess or reuse a stale model ID.
+
+| Region | Text-to-video reference | Image-to-video reference |
+|---|---|---|
+| Global | https://platform.minimax.io/docs/api-reference/video-generation-t2v | https://platform.minimax.io/docs/api-reference/video-generation-i2v |
+| China | https://platform.minimaxi.com/docs/api-reference/video-generation-t2v | https://platform.minimaxi.com/docs/api-reference/video-generation-i2v |
+
+```bash
+export MINIMAX_VIDEO_MODEL="<model ID from the selected region's current API reference>"
+```
+
+## Build the Approved Request
+
+For text-to-video, start with only the required fields. Add optional fields only when they appear in the current API reference and the user has approved their values.
+
+```bash
+jq -n \
+  --arg model "$MINIMAX_VIDEO_MODEL" \
+  --arg prompt "<approved prompt>" \
+  '{model: $model, prompt: $prompt}' > request.json
+```
+
+For image-to-video, add the approved first-frame image. The API accepts a public image URL or a Base64 data URL; check the current size, format, dimension, and aspect-ratio requirements before submitting.
+
+```bash
+jq -n \
+  --arg model "$MINIMAX_VIDEO_MODEL" \
+  --arg prompt "<approved prompt>" \
+  --arg first_frame_image "<approved image URL or data URL>" \
+  '{model: $model, prompt: $prompt, first_frame_image: $first_frame_image}' > request.json
+```
+
+Show the complete `request.json` to the user and get final confirmation before continuing.
+
+## Create the Task
+
+```bash
+CREATE_RESPONSE="$(curl -sS -X POST "$MINIMAX_API_BASE/video_generation" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @request.json)"
+
+echo "$CREATE_RESPONSE" | jq .
+[ "$(echo "$CREATE_RESPONSE" | jq -r '.base_resp.status_code')" = "0" ] || exit 1
+TASK_ID="$(echo "$CREATE_RESPONSE" | jq -r '.task_id // empty')"
+[ -n "$TASK_ID" ] || exit 1
+```
+
+Do not repeat this command automatically if the response is interrupted or ambiguous. Query the returned task ID when available; otherwise ask the user before creating another task.
+
+## Poll and Retrieve the Video
+
+Poll at five-second intervals until the API returns a terminal status. Stop on unknown statuses instead of guessing.
+
+```bash
+while true; do
+  STATUS_RESPONSE="$(curl -sS -G "$MINIMAX_API_BASE/query/video_generation" \
+    -H "Authorization: Bearer $MINIMAX_API_KEY" \
+    --data-urlencode "task_id=$TASK_ID")"
+
+  [ "$(echo "$STATUS_RESPONSE" | jq -r '.base_resp.status_code')" = "0" ] || {
+    echo "$STATUS_RESPONSE" | jq .
+    exit 1
+  }
+
+  STATUS="$(echo "$STATUS_RESPONSE" | jq -r '.status // empty')"
+  echo "task=$TASK_ID status=$STATUS"
+  case "$STATUS" in
+    Success)
+      FILE_ID="$(echo "$STATUS_RESPONSE" | jq -r '.file_id // empty')"
+      [ -n "$FILE_ID" ] || exit 1
+      break
+      ;;
+    Fail)
+      echo "$STATUS_RESPONSE" | jq .
+      exit 1
+      ;;
+    Preparing|Queueing|Processing)
+      sleep 5
+      ;;
+    *)
+      echo "Unknown video generation status: $STATUS"
+      exit 1
+      ;;
+  esac
+done
+
+FILE_RESPONSE="$(curl -sS -G "$MINIMAX_API_BASE/files/retrieve" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  --data-urlencode "file_id=$FILE_ID")"
+
+[ "$(echo "$FILE_RESPONSE" | jq -r '.base_resp.status_code')" = "0" ] || {
+  echo "$FILE_RESPONSE" | jq .
+  exit 1
+}
+DOWNLOAD_URL="$(echo "$FILE_RESPONSE" | jq -r '.file.download_url // empty')"
+[ -n "$DOWNLOAD_URL" ] || exit 1
+```
+
+The download URL is temporary. Import it promptly if the user wants to use the asset in the narration workflow:
+
+```bash
+narrator-ai-cli file transfer --link "$DOWNLOAD_URL" --json
+```
+
+Show the imported file details and get user confirmation before using its `file_id` in any downstream task. Keep normal source, subtitle, BGM, dubbing, and narration-template selection in the standard Narrator AI workflow.
+
+## Official Status and Download References
+
+| Region | Task status | File download |
+|---|---|---|
+| Global | https://platform.minimax.io/docs/api-reference/video-generation-query | https://platform.minimax.io/docs/api-reference/video-generation-download |
+| China | https://platform.minimaxi.com/docs/api-reference/video-generation-query | https://platform.minimaxi.com/docs/api-reference/video-generation-download |


### PR DESCRIPTION
Reason: add target video capability using existing tool/provider pattern

## Summary
- Add an optional MiniMax text-to-video and image-to-video workflow for generated narration assets.
- Document both global and China API regions, explicit approval, asynchronous polling, file retrieval, and CLI import.
- Keep model selection tied to the current official API reference and clarify credential and first-frame data handling.

## Checks
- `git diff --check`
- Verified Markdown code fences and local links
- Parsed all Bash examples with `bash -n`
- Validated both request JSON examples with `jq`
- Verified all linked MiniMax API references return HTTP 200
- Ran the configured secret-regex scan